### PR TITLE
Add support for user installs

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -267,9 +267,9 @@ async def _calculate_per_user_costs(
         created_at_gte=created_at_gte,
     )
     threads_cache: dict[int, threads.Thread] = {}
-    per_user_per_model_input_tokens: dict[int, dict[gpt.OpenAIModel, int]] = (
-        defaultdict(lambda: defaultdict(int))
-    )
+    per_user_per_model_input_tokens: dict[
+        int, dict[gpt.OpenAIModel, int]
+    ] = defaultdict(lambda: defaultdict(int))
     for message in messages:
         if message["role"] != "user":
             continue

--- a/app/main.py
+++ b/app/main.py
@@ -81,20 +81,20 @@ class Bot(discord.Client):
 intents = discord.Intents.default()
 intents.message_content = True
 
-allowed_installs = discord.AppInstallationType(guild=True, user=True)
+allowed_installs = discord.app_commands.AppInstallationType(guild=True, user=True)
 
-allowed_contexts = discord.AppCommandContext(
+allowed_contexts = discord.app_commands.AppCommandContext(
     guild=True,
     dm_channel=True,
     private_channel=True,
 )
 
-bot = Bot(
-    intents=intents,
+bot = Bot(intents=intents)
+command_tree = discord.app_commands.CommandTree(
+    bot,
     allowed_contexts=allowed_contexts,
     allowed_installs=allowed_installs,
 )
-command_tree = discord.app_commands.CommandTree(bot)
 
 
 DISCORD_USER_ID_WHITELIST = {

--- a/app/main.py
+++ b/app/main.py
@@ -81,8 +81,19 @@ class Bot(discord.Client):
 intents = discord.Intents.default()
 intents.message_content = True
 
+allowed_installs = discord.AppInstallationType(guild=True, user=True)
 
-bot = Bot(intents=intents)
+allowed_contexts = discord.AppCommandContext(
+    guild=True,
+    dm_channel=True,
+    private_channel=True,
+)
+
+bot = Bot(
+    intents=intents,
+    allowed_contexts=allowed_contexts,
+    allowed_installs=allowed_installs,
+)
 command_tree = discord.app_commands.CommandTree(bot)
 
 
@@ -256,9 +267,9 @@ async def _calculate_per_user_costs(
         created_at_gte=created_at_gte,
     )
     threads_cache: dict[int, threads.Thread] = {}
-    per_user_per_model_input_tokens: dict[
-        int, dict[gpt.OpenAIModel, int]
-    ] = defaultdict(lambda: defaultdict(int))
+    per_user_per_model_input_tokens: dict[int, dict[gpt.OpenAIModel, int]] = (
+        defaultdict(lambda: defaultdict(int))
+    )
     for message in messages:
         if message["role"] != "user":
             continue

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 asyncpg
 backoff
 databases
-discord.py
+git+https://github.com/Rapptz/discord.py#egg=discord.py
 httpx
 openai<1.0.0
 python-dotenv

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 asyncpg
 backoff
 databases
-git+https://github.com/Rapptz/discord.py#egg=discord.py
+git+https://github.com/Rapptz/discord.py.git@efe81a67fb55f9f2a67bb84810be729ed8f09bc3
 httpx
 openai<1.0.0
 python-dotenv


### PR DESCRIPTION
Discord recently added a feature which allows discord bots to be installed to a user instead of/alongside a guild. This allows for slash command usage in DMs, group chats or guilds where the bot is not invited if the user has the app installed to their user. These changes are the minimum required for the current slash commands to work globally, and there's no concern over usage of these commands sinec they're already behind a whitelist. For some reason discord.py haven't released a new version in almost a year so changing the requirements to fetch discord.py from the git is required to make sure support exists.