### PR TITLE
Implement attempt to continue code blocks between chunked messages.

### DIFF
--- a/.github/workflows/prodution-deploy.yml
+++ b/.github/workflows/prodution-deploy.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - master
-      - realistikdash/master
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/prodution-deploy.yml
+++ b/.github/workflows/prodution-deploy.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - master
+      - realistikdash/master
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/app/main.py
+++ b/app/main.py
@@ -136,14 +136,14 @@ def split_message(message: str, max_length: int) -> list[str]:
         return [message[:split_index]] + split_message(
             message[split_index:], max_length
         )
-    
+
 
 # NOTE: An empty string is considered as a valid language.
 def get_unclosed_block(chunk: str) -> str | None:
     # Even means all blocks were closed correctly.
     if chunk.count("```") % 2 == 0:
         return None
-    
+
     # Find the last block and get its language using the format ```<language>\n
     block_index = chunk.rfind("```")
     remaining_slice = chunk[block_index:]

--- a/app/main.py
+++ b/app/main.py
@@ -139,7 +139,7 @@ def split_message(message: str, max_length: int) -> list[str]:
 
 
 # NOTE: An empty string is considered as a valid language.
-def get_unclosed_block(chunk: str) -> str | None:
+def get_unclosed_block_language(chunk: str) -> str | None:
     # Even means all blocks were closed correctly.
     if chunk.count("```") % 2 == 0:
         return None
@@ -252,7 +252,7 @@ async def on_message(message: discord.Message):
                 chunk = f"```{requires_code_block_language}\n" + chunk
                 requires_code_block_language = None
 
-            requires_code_block_language = get_unclosed_block(chunk)
+            requires_code_block_language = get_unclosed_block_language(chunk)
             if requires_code_block_language is not None:
                 chunk += "\n```"
 

--- a/app/main.py
+++ b/app/main.py
@@ -138,7 +138,7 @@ def split_message(message: str, max_length: int) -> list[str]:
         )
 
 
-def get_unclosed_block_language(chunk: str) -> str | None:
+def get_unclosed_code_block_language(chunk: str) -> str | None:
     """\
     Given an input string representing Discord message content,
     find the last unclosed code block and return its language.
@@ -260,7 +260,7 @@ async def on_message(message: discord.Message):
                 chunk = f"```{requires_code_block_language}\n" + chunk
                 requires_code_block_language = None
 
-            requires_code_block_language = get_unclosed_block_language(chunk)
+            requires_code_block_language = get_unclosed_code_block_language(chunk)
             if requires_code_block_language is not None:
                 chunk += "\n```"
 

--- a/app/main.py
+++ b/app/main.py
@@ -138,8 +138,16 @@ def split_message(message: str, max_length: int) -> list[str]:
         )
 
 
-# NOTE: An empty string is considered as a valid language.
 def get_unclosed_block_language(chunk: str) -> str | None:
+    """\
+    Given an input string representing Discord message content,
+    find the last unclosed code block and return its language.
+
+    For example, for the following text: "```python\nprint('Hello, World!')",
+    the function should return "python".
+
+    NOTE: An empty string is considered as a valid language.
+    """
     # Even means all blocks were closed correctly.
     if chunk.count("```") % 2 == 0:
         return None

--- a/app/main.py
+++ b/app/main.py
@@ -247,12 +247,14 @@ async def on_message(message: discord.Message):
 
         # Handle code blocks which may exceed the previous message.
         requires_code_block_language = None
-        for chunk in split_message(gpt_response_content, 1989):
+        for chunk in split_message(gpt_response_content, 1985):
             if requires_code_block_language is not None:
                 chunk = f"```{requires_code_block_language}\n" + chunk
                 requires_code_block_language = None
 
             requires_code_block_language = get_unclosed_block(chunk)
+            if requires_code_block_language is not None:
+                chunk += "\n```"
 
             await message.channel.send(chunk)
 


### PR DESCRIPTION
Sometimes, code blocks would be split between multiple messages, resulting in an unreadable mess. This PR aims to handle such cases by closing unclosed blocks and opening a new one in the next message if the previous one had to be closed. This PR also handles the preservation of the language information between messages.

### Notes:
- Only the `get_unclosed_block` function has been tested here. Rest is fairly simple so it should work:tm:
- The decrease in the split size is to account for the worst case size change made through this operation. Supported languages tend to max out at approximately 8 chars, and then accounting the opening and closing statements.