### PR TITLE
Add a `/query` command.

### DIFF
--- a/app/discord_message_utils.py
+++ b/app/discord_message_utils.py
@@ -36,3 +36,30 @@ def split_message_into_chunks(message: str, *, max_length: int) -> list[str]:
         return [message[:split_index]] + split_message_into_chunks(
             message[split_index:], max_length=max_length
         )
+    
+
+def smart_split_message_into_chunks(message: str, *, max_length: int) -> list[str]:
+    """Like `split_message_into_chunks`, but also considers code blocks."""
+
+    split_messages = split_message_into_chunks(
+        message,
+        # Magic number to account for MD code embed headers.
+        max_length=max_length - 15,
+    )
+    output_messages = []
+
+    for message_chunk in split_messages:
+        if code_block_language is not None:
+            message_chunk = f"```{code_block_language}\n" + message_chunk
+            code_block_language = None
+
+        code_block_language = (
+            get_unclosed_code_block_language(message_chunk)
+        )
+        if code_block_language is not None:
+            message_chunk += "\n```"
+
+        output_messages.append(message_chunk)
+    
+    return output_messages
+

--- a/app/discord_message_utils.py
+++ b/app/discord_message_utils.py
@@ -47,6 +47,7 @@ def smart_split_message_into_chunks(message: str, *, max_length: int) -> list[st
         max_length=max_length - 15,
     )
     output_messages = []
+    code_block_language = None
 
     for message_chunk in split_messages:
         if code_block_language is not None:

--- a/app/discord_message_utils.py
+++ b/app/discord_message_utils.py
@@ -36,7 +36,7 @@ def split_message_into_chunks(message: str, *, max_length: int) -> list[str]:
         return [message[:split_index]] + split_message_into_chunks(
             message[split_index:], max_length=max_length
         )
-    
+
 
 def smart_split_message_into_chunks(message: str, *, max_length: int) -> list[str]:
     """Like `split_message_into_chunks`, but also considers code blocks."""
@@ -53,13 +53,10 @@ def smart_split_message_into_chunks(message: str, *, max_length: int) -> list[st
             message_chunk = f"```{code_block_language}\n" + message_chunk
             code_block_language = None
 
-        code_block_language = (
-            get_unclosed_code_block_language(message_chunk)
-        )
+        code_block_language = get_unclosed_code_block_language(message_chunk)
         if code_block_language is not None:
             message_chunk += "\n```"
 
         output_messages.append(message_chunk)
-    
-    return output_messages
 
+    return output_messages

--- a/app/main.py
+++ b/app/main.py
@@ -466,8 +466,10 @@ async def transcript(
             file=discord.File(f, filename="transcript.txt"),
         )
 
+
 TRUNCATION_SUFFIX = " (truncated)"
 TRUNCATION_SUFFIX_LENGTH = len(TRUNCATION_SUFFIX)
+
 
 @command_tree.command(name=command_name("query"))
 async def query(

--- a/app/main.py
+++ b/app/main.py
@@ -466,6 +466,35 @@ async def transcript(
             file=discord.File(f, filename="transcript.txt"),
         )
 
+TRUNCATION_SUFFIX = " (truncated)"
+TRUNCATION_SUFFIX_LENGTH = len(TRUNCATION_SUFFIX)
+
+@command_tree.command(name=command_name("query"))
+async def query(
+    interaction: discord.Interaction,
+    query: str,
+    model: gpt.OpenAIModel = gpt.OpenAIModel.GPT_4_OMNI,
+):
+    """Query a model without any context."""
+
+    result = await ai_conversations.send_message_without_context(
+        bot,
+        interaction,
+        query,
+        model,
+    )
+
+    # I do not think interactions allow multiple messages.
+    messages_to_send: list[str] = []
+    if isinstance(result, Error):
+        messages_to_send = result.messages
+    else:
+        messages_to_send = result.response_messages
+
+    # I have no idea whether they actually allow you to send multiple follow-ups.
+    for message_text in messages_to_send:
+        await interaction.followup.send(message_text)
+
 
 if __name__ == "__main__":
     bot.run(settings.DISCORD_TOKEN)

--- a/app/main.py
+++ b/app/main.py
@@ -467,10 +467,6 @@ async def transcript(
         )
 
 
-TRUNCATION_SUFFIX = " (truncated)"
-TRUNCATION_SUFFIX_LENGTH = len(TRUNCATION_SUFFIX)
-
-
 @command_tree.command(name=command_name("query"))
 async def query(
     interaction: discord.Interaction,
@@ -478,6 +474,8 @@ async def query(
     model: gpt.OpenAIModel = gpt.OpenAIModel.GPT_4_OMNI,
 ):
     """Query a model without any context."""
+
+    await interaction.response.defer()
 
     result = await ai_conversations.send_message_without_context(
         bot,

--- a/app/usecases/ai_conversations.py
+++ b/app/usecases/ai_conversations.py
@@ -50,7 +50,10 @@ class _GptRequestResponse(NamedTuple):
     input_tokens: int
     output_tokens: int
 
-async def _make_gpt_request(message_history: list[gpt.Message], model: gpt.OpenAIModel) -> _GptRequestResponse | Error:
+
+async def _make_gpt_request(
+    message_history: list[gpt.Message], model: gpt.OpenAIModel
+) -> _GptRequestResponse | Error:
     functions = openai_functions.get_full_openai_functions_schema()
     try:
         gpt_response = await gpt.send(
@@ -243,9 +246,11 @@ async def send_message_to_thread(
             return gpt_response
 
         # Handle code blocks which may exceed the previous message.
-        response_messages: list[str] = discord_message_utils.smart_split_message_into_chunks(
-            gpt_response.response_content,
-            max_length=2000,
+        response_messages: list[str] = (
+            discord_message_utils.smart_split_message_into_chunks(
+                gpt_response.response_content,
+                max_length=2000,
+            )
         )
 
         await thread_messages.create(
@@ -289,7 +294,7 @@ async def send_message_without_context(
             code=ErrorCode.UNAUTHORIZED,
             messages=["User is not authorised to use this bot"],
         )
-    
+
     prompt = f"{interaction.user.name}: {message_content}"
 
     user_messages: list[MessageContent] = [
@@ -308,11 +313,13 @@ async def send_message_without_context(
     gpt_response = await _make_gpt_request(message_context, model)
     if isinstance(gpt_response, Error):
         return gpt_response
-    
+
     # TODO: Track input and output tokens here.
 
-    response_messages: list[str] = discord_message_utils.smart_split_message_into_chunks(
-        gpt_response.response_content,
-        max_length=2000,
+    response_messages: list[str] = (
+        discord_message_utils.smart_split_message_into_chunks(
+            gpt_response.response_content,
+            max_length=2000,
+        )
     )
     return SendAndReceiveResponse(response_messages=response_messages)

--- a/app/usecases/ai_conversations.py
+++ b/app/usecases/ai_conversations.py
@@ -295,8 +295,8 @@ async def send_message_without_context(
             messages=["User is not authorised to use this bot"],
         )
 
-    #author_name = get_author_name(interaction.user.name)
-    #prompt = f"{author_name}: {message_content}"
+    # author_name = get_author_name(interaction.user.name)
+    # prompt = f"{author_name}: {message_content}"
 
     # Since there is no context nor multi-user convos, we can just send the message as is
     prompt = message_content

--- a/app/usecases/ai_conversations.py
+++ b/app/usecases/ai_conversations.py
@@ -295,7 +295,8 @@ async def send_message_without_context(
             messages=["User is not authorised to use this bot"],
         )
 
-    prompt = f"{interaction.user.name}: {message_content}"
+    author_name = get_author_name(interaction.user.name)
+    prompt = f"{author_name}: {message_content}"
 
     user_messages: list[MessageContent] = [
         {

--- a/app/usecases/ai_conversations.py
+++ b/app/usecases/ai_conversations.py
@@ -295,8 +295,11 @@ async def send_message_without_context(
             messages=["User is not authorised to use this bot"],
         )
 
-    author_name = get_author_name(interaction.user.name)
-    prompt = f"{author_name}: {message_content}"
+    #author_name = get_author_name(interaction.user.name)
+    #prompt = f"{author_name}: {message_content}"
+
+    # Since there is no context nor multi-user convos, we can just send the message as is
+    prompt = message_content
 
     user_messages: list[MessageContent] = [
         {


### PR DESCRIPTION
This implements the `/query` slash command to allow you to quickly run queries without the need for context. This is aimed at being used in environments where the bot/you don't have access to threads (such as DMs and group chats). 

Long-term, this would consider *some* per-user context (maybe 5 messages).

On top of this, it genericises some of the API to be more re-usable (such as smart message splitting and the GPT query loop).

### Note
This does not integrate with the cost count implemented as the logic there was too thread-focused to be done simply.

Also completely untested.