### PR TITLE
Implement Personal Message Context

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -520,11 +520,13 @@ async def clear_context(interaction: discord.Interaction):
             ephemeral=True,
         )
         return
-    
+
     await interaction.response.defer()
     deleted_messages = await personal_messages.delete_from_user_id(interaction.user.id)
 
-    await interaction.followup.send(f"Context cleared (deleted {deleted_messages} messages)!")
+    await interaction.followup.send(
+        f"Context cleared (deleted {deleted_messages} messages)!"
+    )
 
 
 if __name__ == "__main__":

--- a/app/main.py
+++ b/app/main.py
@@ -472,17 +472,26 @@ async def query(
     interaction: discord.Interaction,
     query: str,
     model: gpt.AIModel = gpt.AIModel.OPENAI_GPT_4_OMNI,
+    use_context: bool = True,
 ):
     """Query a model without any context."""
 
     await interaction.response.defer()
 
-    result = await ai_conversations.send_message_without_context(
-        bot,
-        interaction,
-        query,
-        model,
-    )
+    if use_context:
+        result = await ai_conversations.send_message_with_personal_context(
+            bot,
+            interaction,
+            query,
+            model,
+        )
+    else:
+        result = await ai_conversations.send_message_without_context(
+            bot,
+            interaction,
+            query,
+            model,
+        )
 
     # I do not think interactions allow multiple messages.
     messages_to_send: list[str] = []

--- a/app/repositories/personal_messages.py
+++ b/app/repositories/personal_messages.py
@@ -1,0 +1,15 @@
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Literal
+
+from pydantic import BaseModel
+
+
+class PersonalMessage(BaseModel):
+    id: int
+    user_id: int
+    content: str
+    role: Literal["user", "assistant"]
+    tokens_used: int
+    created_at: datetime

--- a/app/repositories/personal_messages.py
+++ b/app/repositories/personal_messages.py
@@ -1,9 +1,9 @@
 from __future__ import annotations
 
+from collections.abc import Mapping
 from datetime import datetime
 from typing import Any
 from typing import Literal
-from typing import Mapping
 
 from pydantic import BaseModel
 
@@ -85,7 +85,9 @@ async def fetch_last_n(user_id: int, n: int) -> list[PersonalMessage]:
     return [deserialize(record) for record in records]
 
 
-async def fetch_created_before(user_id: int, created_at: datetime) -> list[PersonalMessage]:
+async def fetch_created_before(
+    user_id: int, created_at: datetime
+) -> list[PersonalMessage]:
     query = f"""\
         SELECT {READ_PARAMS}
         FROM personal_messages

--- a/app/repositories/personal_messages.py
+++ b/app/repositories/personal_messages.py
@@ -96,10 +96,10 @@ async def fetch_created_before(user_id: int, created_at: datetime) -> list[Perso
     return [deserialize(record) for record in records]
 
 
-async def delete_from_user_id(user_id: int) -> None:
+async def delete_from_user_id(user_id: int) -> int:
     query = f"""\
         DELETE FROM personal_messages
         WHERE user_id = :user_id
     """
     values = {"user_id": user_id}
-    await state.write_database.execute(query=query, values=values)
+    return await state.write_database.execute(query=query, values=values)

--- a/app/repositories/personal_messages.py
+++ b/app/repositories/personal_messages.py
@@ -1,9 +1,22 @@
 from __future__ import annotations
 
 from datetime import datetime
+from typing import Any
 from typing import Literal
+from typing import Mapping
 
 from pydantic import BaseModel
+
+from app import state
+
+READ_PARAMS = """\
+    id,
+    user_id,
+    content,
+    role,
+    tokens_used,
+    created_at
+"""
 
 
 class PersonalMessage(BaseModel):
@@ -13,3 +26,60 @@ class PersonalMessage(BaseModel):
     role: Literal["user", "assistant"]
     tokens_used: int
     created_at: datetime
+
+
+def deserialize(record: Mapping[str, Any]) -> PersonalMessage:
+    return PersonalMessage(
+        id=record["id"],
+        user_id=record["user_id"],
+        content=record["content"],
+        role=record["role"],
+        tokens_used=record["tokens_used"],
+        created_at=record["created_at"],
+    )
+
+
+async def create(
+    user_id: int,
+    content: str,
+    role: Literal["user", "assistant"],
+    tokens_used: int,
+) -> PersonalMessage:
+    query = f"""\
+        INSERT INTO personal_messages (user_id, content, role, tokens_used)
+        VALUES (:user_id, :content, :role, :tokens_used)
+        RETURNING {READ_PARAMS}
+    """
+    values: dict[str, Any] = {
+        "user_id": user_id,
+        "content": content,
+        "role": role,
+        "tokens_used": tokens_used,
+    }
+    record = await state.write_database.fetch_one(query=query, values=values)
+    assert record is not None
+    return deserialize(record)
+
+
+async def fetch_one(personal_message_id: int) -> PersonalMessage | None:
+    query = f"""\
+        SELECT {READ_PARAMS}
+        FROM personal_messages
+        WHERE id = :personal_message_id
+    """
+    values = {"personal_message_id": personal_message_id}
+    record = await state.read_database.fetch_one(query=query, values=values)
+    return deserialize(record) if record is not None else None
+
+
+async def fetch_last_n(user_id: int, n: int) -> list[PersonalMessage]:
+    query = f"""\
+        SELECT {READ_PARAMS}
+        FROM personal_messages
+        WHERE user_id = :user_id
+        ORDER BY created_at DESC
+        LIMIT :n
+    """
+    values = {"user_id": user_id, "n": n}
+    records = await state.read_database.fetch_all(query=query, values=values)
+    return [deserialize(record) for record in records]

--- a/app/repositories/personal_messages.py
+++ b/app/repositories/personal_messages.py
@@ -94,3 +94,12 @@ async def fetch_created_before(user_id: int, created_at: datetime) -> list[Perso
     values = {"user_id": user_id, "created_at": created_at}
     records = await state.read_database.fetch_all(query=query, values=values)
     return [deserialize(record) for record in records]
+
+
+async def delete_from_user_id(user_id: int) -> None:
+    query = f"""\
+        DELETE FROM personal_messages
+        WHERE user_id = :user_id
+    """
+    values = {"user_id": user_id}
+    await state.write_database.execute(query=query, values=values)

--- a/app/repositories/personal_messages.py
+++ b/app/repositories/personal_messages.py
@@ -83,3 +83,14 @@ async def fetch_last_n(user_id: int, n: int) -> list[PersonalMessage]:
     values = {"user_id": user_id, "n": n}
     records = await state.read_database.fetch_all(query=query, values=values)
     return [deserialize(record) for record in records]
+
+
+async def fetch_created_before(user_id: int, created_at: datetime) -> list[PersonalMessage]:
+    query = f"""\
+        SELECT {READ_PARAMS}
+        FROM personal_messages
+        WHERE user_id = :user_id AND created_at < :created_at
+    """
+    values = {"user_id": user_id, "created_at": created_at}
+    records = await state.read_database.fetch_all(query=query, values=values)
+    return [deserialize(record) for record in records]

--- a/app/usecases/ai_conversations.py
+++ b/app/usecases/ai_conversations.py
@@ -12,9 +12,9 @@ from app.adapters.openai.gpt import MessageContent
 from app.errors import Error
 from app.errors import ErrorCode
 from app.models import DiscordBot
+from app.repositories import personal_messages
 from app.repositories import thread_messages
 from app.repositories import threads
-from app.repositories import personal_messages
 
 
 DISCORD_USER_ID_WHITELIST: set[int] = {
@@ -329,7 +329,9 @@ async def send_message_without_context(
     )
     return SendAndReceiveResponse(response_messages=response_messages)
 
+
 PERSONAL_CONTEXT_SIZE = 5
+
 
 async def send_message_with_personal_context(
     bot: DiscordBot,
@@ -373,7 +375,7 @@ async def send_message_with_personal_context(
             "role": "user",
             "content": [{"type": "text", "text": prompt}],
         }
-    ] # type: ignore
+    ]  # type: ignore
     # TODO: fix type error?
 
     gpt_response = await _make_gpt_request(
@@ -382,7 +384,7 @@ async def send_message_with_personal_context(
     )
     if isinstance(gpt_response, Error):
         return gpt_response
-    
+
     # Log the user message
     await personal_messages.create(
         user_id=interaction.user.id,

--- a/database/migrations/00006_create_personal_messages_table.down.sql
+++ b/database/migrations/00006_create_personal_messages_table.down.sql
@@ -1,0 +1,1 @@
+DROP TABLE personal_messages;

--- a/database/migrations/00006_create_personal_messages_table.up.sql
+++ b/database/migrations/00006_create_personal_messages_table.up.sql
@@ -1,0 +1,12 @@
+CREATE TABLE personal_messages (
+    id INT NOT NULL PRIMARY KEY, -- Differs from message_id as it includes responses
+    user_id BIGINT NOT NULL,
+    content TEXT NOT NULL,
+    role TEXT NOT NULL,
+    -- Input tokens, sus but thread_messages does it lol.
+    -- Perhaps use a "source" enum to differentiate between user input and bot output?
+    tokens_used INT NOT NULL,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+
+    INDEX ON (user_id)
+);

--- a/database/migrations/00006_create_personal_messages_table.up.sql
+++ b/database/migrations/00006_create_personal_messages_table.up.sql
@@ -3,8 +3,8 @@ CREATE TABLE personal_messages (
     user_id BIGINT NOT NULL,
     content TEXT NOT NULL,
     role TEXT NOT NULL,
-    -- Input tokens, sus but thread_messages does it lol.
     -- Perhaps use a "source" enum to differentiate between user input and bot output?
+    -- Will let us use injecting system messages.
     tokens_used INT NOT NULL,
     created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
 


### PR DESCRIPTION
This PR adds keeping track of personal context for queries done outside of threads, alongside the `clear_context` command.

This aims to make using the `query` command more viable for usecases where the bot cannot create a thread (such as group chats), allowing for more fluent conversations. The `clear_context` command was added to make context switching easier, as you dont want the bot bringing up your cooking queries when you want to ask it about code.

### Potential issues
- Personal messages are not counted in the monthly cost and even if they were, context clearing would invalidate them. Perhaps use a "deleted" field in the database to account for these.
- Currently, context limits are handled by a constant (last `5` messages), which is pretty small. Perhaps using a time based one (messages from the last hour or so) would be more convenient and adding input token calculations into the fetch query directly (last `n` tokens until you hit the input token limit for the model) to max out the context.