### PR TITLE
Add complete support for user installs.

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -33,8 +33,19 @@ MAX_CONTENT_LENGTH = 100
 intents = discord.Intents.default()
 intents.message_content = True
 
+allowed_installs = discord.app_commands.AppInstallationType(guild=True, user=True)
+allowed_contexts = discord.app_commands.AppCommandContext(
+    guild=True,
+    dm_channel=True,
+    private_channel=True,
+)
+
 bot = DiscordBot(intents=intents)
-command_tree = discord.app_commands.CommandTree(bot)
+command_tree = discord.app_commands.CommandTree(
+    bot,
+    allowed_contexts=allowed_contexts,
+    allowed_installs=allowed_installs,
+)
 
 
 def command_name(command_name: str) -> str:


### PR DESCRIPTION
Replaces #17 (at the request of the contributor) in accordance with modern discordpy.

Enables the usage of commands (mainly `/query`) in DMs and group chats. Simple change.