### PR TITLE
remove older models & added o3, o3-pro & o4-mini

### DIFF
--- a/app/adapters/openai/gpt.py
+++ b/app/adapters/openai/gpt.py
@@ -25,10 +25,9 @@ deepseek_client = openai.AsyncOpenAI(
 class AIModel(StrEnum):
     # OpenAI
     OPENAI_GPT_4_OMNI = "gpt-4o"
-    OPENAI_CHATGPT_4O_LATEST = "chatgpt-4o-latest"
-    OPENAI_GPT_O1 = "o1"
-    OPENAI_GPT_O1_MINI = "o1-mini"
-    OPENAI_GPT_O3_MINI = "o3-mini"
+    OPENAI_GPT_O3 = "o3"
+    OPENAI_GPT_O3_PRO = "o3-pro"
+    OPENAI_GPT_O4_MINI = "o4-mini"
 
     # DeepSeek
     DEEPSEEK_CHAT = "deepseek-chat"
@@ -94,11 +93,10 @@ async def send(
     if model in {AIModel.DEEPSEEK_CHAT, AIModel.DEEPSEEK_REASONER}:
         return await deepseek_client.chat.completions.create(**kwargs)
     elif model in {
-        AIModel.OPENAI_CHATGPT_4O_LATEST,
         AIModel.OPENAI_GPT_4_OMNI,
-        AIModel.OPENAI_GPT_O1,
-        AIModel.OPENAI_GPT_O1_MINI,
-        AIModel.OPENAI_GPT_O3_MINI,
+        AIModel.OPENAI_GPT_O3,
+        AIModel.OPENAI_GPT_O3_PRO,
+        AIModel.OPENAI_GPT_O4_MINI,
     }:
         return await openai_client.chat.completions.create(**kwargs)
     else:

--- a/app/openai_pricing.py
+++ b/app/openai_pricing.py
@@ -10,15 +10,11 @@ def input_price_per_million_tokens(model: AIModel) -> float:
     match model:
         case AIModel.OPENAI_GPT_4_OMNI:
             return 2.50
-        # Not directly listed on the pricing page
-        # (as the latest model is often changing)
-        case AIModel.OPENAI_CHATGPT_4O_LATEST:
-            return 2.50
-        case AIModel.OPENAI_GPT_O1:
-            return 15.00
-        case AIModel.OPENAI_GPT_O1_MINI:
-            return 1.10
-        case AIModel.OPENAI_GPT_O3_MINI:
+        case AIModel.OPENAI_GPT_O3:
+            return 2.00
+        case AIModel.OPENAI_GPT_O3_PRO:
+            return 20.00
+        case AIModel.OPENAI_GPT_O4_MINI:
             return 1.10
         case AIModel.DEEPSEEK_CHAT:
             return 0.27
@@ -32,15 +28,11 @@ def output_price_per_million_tokens(model: AIModel) -> float:
     match model:
         case AIModel.OPENAI_GPT_4_OMNI:
             return 10.00
-        # Not directly listed on the pricing page
-        # (as the latest model is often changing)
-        case AIModel.OPENAI_CHATGPT_4O_LATEST:
-            return 10.00
-        case AIModel.OPENAI_GPT_O1:
-            return 60.00
-        case AIModel.OPENAI_GPT_O1_MINI:
-            return 4.40
-        case AIModel.OPENAI_GPT_O3_MINI:
+        case AIModel.OPENAI_GPT_O3:
+            return 8.00
+        case AIModel.OPENAI_GPT_O3_PRO:
+            return 80.00
+        case AIModel.OPENAI_GPT_O4_MINI:
             return 4.40
         case AIModel.DEEPSEEK_CHAT:
             return 1.10


### PR DESCRIPTION
`o3` is now like 13% the price of `o1` and `o4-mini` has the same pricing as `o3-mini` and `o1-mini`

kept `gpt-4o` since it is still offered on chatgpt.com

`o3-pro` is quite expensive (20i/80o), maybe you can consider removing it

committed on my friend's laptop and *kinda* tested - i don't have an oai api key but it seems like the api recognized i don't have permissions to use the models, so i think it should work!