### PR TITLE
Use self-hosted VPC runner for deployments

### DIFF
--- a/.github/workflows/prodution-deploy.yml
+++ b/.github/workflows/prodution-deploy.yml
@@ -11,7 +11,7 @@ concurrency:
 
 jobs:
   production-deploy:
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, vpc]
 
     steps:
       - name: Check out latest commit


### PR DESCRIPTION
Switch to self-hosted VPC runner for K8s deployments (K8s API is VPC-only).