### PR TITLE
Update OpenAI models and Responses API usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # ai-discord-bot
-A discord bot for creating multi-user conversations with OpenAI models (namely GPT-4)
+A discord bot for creating multi-user conversations with OpenAI and DeepSeek models.
 
 # installation
 ```sh

--- a/app/adapters/openai/gpt.py
+++ b/app/adapters/openai/gpt.py
@@ -1,4 +1,5 @@
 from collections.abc import Sequence
+from dataclasses import dataclass
 from enum import StrEnum
 from typing import Any
 from typing import Literal
@@ -7,7 +8,6 @@ from typing import TypeAlias
 from typing import TypedDict
 
 import openai
-from openai.types.chat import ChatCompletion
 
 from app import settings
 
@@ -24,16 +24,23 @@ deepseek_client = openai.AsyncOpenAI(
 
 class AIModel(StrEnum):
     # OpenAI
+    OPENAI_GPT_5_5 = "gpt-5.5"
+    OPENAI_GPT_5_4 = "gpt-5.4"
+    OPENAI_GPT_5_4_MINI = "gpt-5.4-mini"
+    OPENAI_GPT_5_4_NANO = "gpt-5.4-nano"
+    OPENAI_GPT_5 = "gpt-5"
+    OPENAI_GPT_5_MINI = "gpt-5-mini"
     OPENAI_GPT_4_OMNI = "gpt-4o"
     OPENAI_GPT_O3 = "o3"
     OPENAI_GPT_O3_PRO = "o3-pro"
     OPENAI_GPT_O4_MINI = "o4-mini"
-    OPENAI_GPT_5 = "gpt-5"
-    OPENAI_GPT_5_MINI = "gpt-5-mini"
 
     # DeepSeek
     DEEPSEEK_CHAT = "deepseek-chat"
     DEEPSEEK_REASONER = "deepseek-reasoner"
+
+
+DEFAULT_AI_MODEL = AIModel.OPENAI_GPT_5_4
 
 
 class TextMessage(TypedDict):
@@ -57,6 +64,7 @@ class Message(TypedDict, total=False):
     role: Required[Literal["user", "assistant", "function"]]
     content: Required[list[MessageContent]]
     name: str  # only exists when role is "function"
+    call_id: str  # only exists for Responses API function outputs
 
 
 class Property(TypedDict, total=False):
@@ -77,29 +85,174 @@ class FunctionSchema(TypedDict):
     parameters: Parameters
 
 
+@dataclass(frozen=True, slots=True)
+class FunctionCall:
+    name: str
+    arguments: str
+    call_id: str | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class AIResponse:
+    response_content: str | None
+    function_calls: list[FunctionCall]
+    input_tokens: int
+    output_tokens: int
+    response_items: list[dict[str, Any]]
+
+
+def _message_content_to_text(content: Sequence[MessageContent]) -> str:
+    output_parts: list[str] = []
+    for content_part in content:
+        if content_part["type"] == "text":
+            output_parts.append(content_part["text"])
+        elif content_part["type"] == "image_url":
+            output_parts.append(content_part["image_url"]["url"])
+    return "\n".join(output_parts)
+
+
+def _message_to_responses_input(message: Message) -> dict[str, Any]:
+    role = message["role"]
+    if role == "function":
+        return {
+            "type": "function_call_output",
+            "call_id": message["call_id"],
+            "output": _message_content_to_text(message["content"]),
+        }
+
+    if role == "assistant":
+        return {
+            "role": "assistant",
+            "content": _message_content_to_text(message["content"]),
+        }
+
+    content: list[dict[str, Any]] = []
+    for content_part in message["content"]:
+        if content_part["type"] == "text":
+            content.append(
+                {
+                    "type": "input_text",
+                    "text": content_part["text"],
+                }
+            )
+        elif content_part["type"] == "image_url":
+            content.append(
+                {
+                    "type": "input_image",
+                    "image_url": content_part["image_url"]["url"],
+                    "detail": "auto",
+                }
+            )
+
+    return {
+        "role": role,
+        "content": content,
+    }
+
+
+def _function_schema_to_responses_tool(schema: FunctionSchema) -> dict[str, Any]:
+    return {
+        "type": "function",
+        "name": schema["name"],
+        "description": schema["description"],
+        "parameters": schema["parameters"],
+        "strict": False,
+    }
+
+
+def _normalize_responses_response(response: Any) -> AIResponse:
+    usage = response.usage
+    response_items = [item.model_dump(exclude_none=True) for item in response.output]
+    function_calls = [
+        FunctionCall(
+            name=item.name,
+            arguments=item.arguments,
+            call_id=item.call_id,
+        )
+        for item in response.output
+        if item.type == "function_call"
+    ]
+
+    return AIResponse(
+        response_content=response.output_text or None,
+        function_calls=function_calls,
+        input_tokens=usage.input_tokens if usage is not None else 0,
+        output_tokens=usage.output_tokens if usage is not None else 0,
+        response_items=response_items,
+    )
+
+
+def _normalize_chat_response(response: Any) -> AIResponse:
+    choice = response.choices[0]
+    message = choice.message
+    function_call = message.function_call
+    function_calls = []
+    if choice.finish_reason == "function_call" and function_call is not None:
+        function_calls.append(
+            FunctionCall(
+                name=function_call.name,
+                arguments=function_call.arguments,
+            )
+        )
+
+    usage = response.usage
+
+    return AIResponse(
+        response_content=message.content,
+        function_calls=function_calls,
+        input_tokens=usage.prompt_tokens if usage is not None else 0,
+        output_tokens=usage.completion_tokens if usage is not None else 0,
+        response_items=[],
+    )
+
+
+def function_call_output_item(
+    function_call: FunctionCall,
+    function_response: MessageContent,
+) -> dict[str, Any]:
+    if function_call.call_id is None:
+        raise ValueError("OpenAI Responses function calls must include a call_id")
+
+    return {
+        "type": "function_call_output",
+        "call_id": function_call.call_id,
+        "output": _message_content_to_text([function_response]),
+    }
+
+
 async def send(
     *,
     model: AIModel,
     messages: Sequence[Message],
     functions: Sequence[FunctionSchema] | None = None,
-) -> ChatCompletion:
+    response_context_items: Sequence[dict[str, Any]] | None = None,
+) -> AIResponse:
     """\
-    Send a message to the OpenAI API, as a given model.
+    Send a message to the selected AI provider, as a given model.
 
-    https://platform.openai.com/docs/api-reference/chat
+    OpenAI models use the Responses API. DeepSeek uses its OpenAI-compatible
+    chat completions endpoint.
     """
-    kwargs: dict[str, Any] = {"model": model.value, "messages": messages}
-    if functions is not None:
-        kwargs["functions"] = functions
-
     if model in {AIModel.DEEPSEEK_CHAT, AIModel.DEEPSEEK_REASONER}:
-        return await deepseek_client.chat.completions.create(**kwargs)
-    elif model in {
-        AIModel.OPENAI_GPT_4_OMNI,
-        AIModel.OPENAI_GPT_O3,
-        AIModel.OPENAI_GPT_O3_PRO,
-        AIModel.OPENAI_GPT_O4_MINI,
-    }:
-        return await openai_client.chat.completions.create(**kwargs)
-    else:
-        raise NotImplementedError(f"Unsupported model: {model}")
+        kwargs: dict[str, Any] = {"model": model.value, "messages": messages}
+        if functions is not None:
+            kwargs["functions"] = functions
+        return _normalize_chat_response(
+            await deepseek_client.chat.completions.create(**kwargs)
+        )
+
+    input_items = [_message_to_responses_input(message) for message in messages]
+    if response_context_items is not None:
+        input_items.extend(response_context_items)
+
+    kwargs = {
+        "model": model.value,
+        "input": input_items,
+        "store": False,
+    }
+    if functions is not None:
+        kwargs["tools"] = [
+            _function_schema_to_responses_tool(function) for function in functions
+        ]
+
+    return _normalize_responses_response(await openai_client.responses.create(**kwargs))

--- a/app/main.py
+++ b/app/main.py
@@ -356,7 +356,7 @@ async def summarize(
 
     try:
         gpt_response = await gpt.send(
-            model=gpt.AIModel.OPENAI_GPT_4_OMNI,
+            model=gpt.DEFAULT_AI_MODEL,
             messages=messages,
         )
     except Exception as exc:
@@ -368,7 +368,7 @@ async def summarize(
         )
         return
 
-    gpt_response_content = gpt_response.choices[0].message.content
+    gpt_response_content = gpt_response.response_content
     assert gpt_response_content is not None
 
     # tokens_spent = gpt_response.usage.total_tokens
@@ -382,7 +382,7 @@ async def summarize(
 @command_tree.command(name=command_name("ai"))
 async def ai(
     interaction: discord.Interaction,
-    model: gpt.AIModel = gpt.AIModel.OPENAI_GPT_4_OMNI,
+    model: gpt.AIModel = gpt.DEFAULT_AI_MODEL,
 ):
     if (
         interaction.channel is not None
@@ -482,7 +482,7 @@ async def transcript(
 async def query(
     interaction: discord.Interaction,
     query: str,
-    model: gpt.AIModel = gpt.AIModel.OPENAI_GPT_4_OMNI,
+    model: gpt.AIModel = gpt.DEFAULT_AI_MODEL,
 ):
     """Query a model without any context."""
 

--- a/app/openai_pricing.py
+++ b/app/openai_pricing.py
@@ -8,6 +8,14 @@ from app.adapters.openai.gpt import AIModel
 
 def input_price_per_million_tokens(model: AIModel) -> float:
     match model:
+        case AIModel.OPENAI_GPT_5_5:
+            return 5.00
+        case AIModel.OPENAI_GPT_5_4:
+            return 2.50
+        case AIModel.OPENAI_GPT_5_4_MINI:
+            return 0.75
+        case AIModel.OPENAI_GPT_5_4_NANO:
+            return 0.20
         case AIModel.OPENAI_GPT_4_OMNI:
             return 2.50
         case AIModel.OPENAI_GPT_O3:
@@ -30,6 +38,14 @@ def input_price_per_million_tokens(model: AIModel) -> float:
 
 def output_price_per_million_tokens(model: AIModel) -> float:
     match model:
+        case AIModel.OPENAI_GPT_5_5:
+            return 30.00
+        case AIModel.OPENAI_GPT_5_4:
+            return 15.00
+        case AIModel.OPENAI_GPT_5_4_MINI:
+            return 4.50
+        case AIModel.OPENAI_GPT_5_4_NANO:
+            return 1.25
         case AIModel.OPENAI_GPT_4_OMNI:
             return 10.00
         case AIModel.OPENAI_GPT_O3:

--- a/app/usecases/ai_conversations.py
+++ b/app/usecases/ai_conversations.py
@@ -1,5 +1,6 @@
 import json
 import traceback
+from typing import Any
 from typing import NamedTuple
 
 import discord
@@ -52,69 +53,24 @@ class _GptRequestResponse(NamedTuple):
     output_tokens: int
 
 
+MAX_FUNCTION_CALL_ROUNDS = 5
+
+
 async def _make_gpt_request(
     message_history: list[gpt.Message], model: gpt.AIModel
 ) -> _GptRequestResponse | Error:
     functions = openai_functions.get_full_openai_functions_schema()
-    try:
-        gpt_response = await gpt.send(
-            model=model,
-            messages=message_history,
-            functions=functions,
-        )
-    except Exception as exc:
-        traceback.print_exc()
-        # NOTE: this is *generally* bad practice to expose this information
-        # to end users, and should be removed if we are to deploy this app
-        # more widely. Right now it's okay because it's a private bot.
-        return Error(
-            code=ErrorCode.UNEXPECTED_ERROR,
-            messages=[
-                f"Request to OpenAI failed with the following error:\n```\n{exc}```"
-            ],
-        )
+    response_context_items: list[dict[str, Any]] = []
+    input_tokens = 0
+    output_tokens = 0
 
-    gpt_choice = gpt_response.choices[0]
-    gpt_message = gpt_choice.message
-
-    if gpt_choice.finish_reason == "stop":
-        assert gpt_message.content is not None
-        gpt_response_content: str = gpt_message.content
-        message_history.append(
-            {
-                "role": gpt_message.role,
-                "content": [
-                    {
-                        "type": "text",
-                        "text": gpt_message.content,
-                    }
-                ],
-            }
-        )
-    elif (
-        gpt_choice.finish_reason == "function_call"
-        and gpt_message.function_call is not None
-    ):
-        function_name = gpt_message.function_call.name
-        function_kwargs = json.loads(gpt_message.function_call.arguments)
-
-        ai_function = openai_functions.ai_functions[function_name]
-        function_response = await ai_function["callback"](**function_kwargs)
-
-        # send function response back to gpt for the final response
-        # TODO: could it call another function?
-        #       i think they may expect/support recursive calls
-        message_history.append(
-            {
-                "role": "function",
-                "name": function_name,
-                "content": [function_response],
-            }
-        )
+    for _ in range(MAX_FUNCTION_CALL_ROUNDS):
         try:
             gpt_response = await gpt.send(
                 model=model,
                 messages=message_history,
+                functions=functions,
+                response_context_items=response_context_items,
             )
         except Exception as exc:
             traceback.print_exc()
@@ -128,23 +84,77 @@ async def _make_gpt_request(
                 ],
             )
 
-        assert gpt_response.choices[0].message.content is not None
-        gpt_response_content = gpt_response.choices[0].message.content
+        input_tokens += gpt_response.input_tokens
+        output_tokens += gpt_response.output_tokens
 
-    else:
-        raise NotImplementedError(
-            f"Unknown chatgpt finish reason: {gpt_choice.finish_reason}"
-        )
+        if not gpt_response.function_calls:
+            assert gpt_response.response_content is not None
+            return _GptRequestResponse(
+                gpt_response.response_content,
+                input_tokens,
+                output_tokens,
+            )
 
-    assert gpt_response.usage is not None
-    input_tokens = gpt_response.usage.prompt_tokens
-    output_tokens = gpt_response.usage.completion_tokens
+        response_context_items.extend(gpt_response.response_items)
+        for function_call in gpt_response.function_calls:
+            function_kwargs = json.loads(function_call.arguments)
 
-    return _GptRequestResponse(
-        gpt_response_content,
-        input_tokens,
-        output_tokens,
+            ai_function = openai_functions.ai_functions[function_call.name]
+            function_response = await ai_function["callback"](**function_kwargs)
+
+            if function_call.call_id is None:
+                message_history.append(
+                    {
+                        "role": "function",
+                        "name": function_call.name,
+                        "content": [function_response],
+                    }
+                )
+            else:
+                response_context_items.append(
+                    gpt.function_call_output_item(function_call, function_response)
+                )
+
+    raise NotImplementedError(
+        f"OpenAI function calling exceeded {MAX_FUNCTION_CALL_ROUNDS} rounds"
     )
+
+
+def _image_url_message_content(image_url: str) -> MessageContent:
+    return {
+        "type": "image_url",
+        "image_url": {"url": image_url},
+    }
+
+
+def _message_content_from_prompt(
+    prompt: str,
+    attachment_urls: list[str],
+) -> tuple[str, list[MessageContent]]:
+    image_urls: list[str] = []
+
+    # Extract image URLs from the prompt and replace them with {IMAGE}
+    prompt_parts = prompt.split()
+    images_seen = 0
+    for i, part in enumerate(prompt_parts):
+        if (part.startswith("http://") or part.startswith("https://")) and any(
+            part.endswith(ext) for ext in gpt.VALID_IMAGE_EXTENSIONS
+        ):
+            image_urls.append(part)
+            prompt_parts[i] = f"{{IMAGE #{images_seen + 1}}}"
+            images_seen += 1
+    prompt = " ".join(prompt_parts)
+
+    new_message_content: list[MessageContent] = [
+        {
+            "type": "text",
+            "text": prompt,
+        }
+    ]
+    for image_url in [*image_urls, *attachment_urls]:
+        new_message_content.append(_image_url_message_content(image_url))
+
+    return prompt, new_message_content
 
 
 class SendAndReceiveResponse(BaseModel):
@@ -198,39 +208,10 @@ async def send_message_to_thread(
             for m in thread_history[-tracked_thread.context_length :]
         ]
 
-        ## Build the new message's prompt
-        image_urls: list[str] = []
-
-        # Extract image URLs from the prompt and replace them with {IMAGE}
-        prompt_parts = prompt.split()
-        images_seen = 0
-        for i, part in enumerate(prompt_parts):
-            if (part.startswith("http://") or part.startswith("https://")) and any(
-                part.endswith(ext) for ext in gpt.VALID_IMAGE_EXTENSIONS
-            ):
-                image_urls.append(part)
-                prompt_parts[i] = f"{{IMAGE #{images_seen + 1}}}"
-                images_seen += 1
-        prompt = " ".join(prompt_parts)
-
-        # Add the new prompt and attachments to the message history
-        new_message_content: list[MessageContent] = []
-        new_message_content.append(
-            {
-                "type": "text",
-                "text": prompt,
-            }
+        prompt, new_message_content = _message_content_from_prompt(
+            prompt,
+            attachment_urls=[attachment.url for attachment in message.attachments],
         )
-        for image_url in image_urls:
-            new_message_content.append(
-                {
-                    "type": "image_url",
-                    "image_url": {"url": image_url},
-                }
-            )
-        for attachment in message.attachments:
-            # TODO: should these be included as {IMAGE #N} at the end of the message?
-            image_urls.append(attachment.url)
 
         message_history.append(
             {

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,3 +1,6 @@
 black
 pre-commit
+pytest
+pytest-asyncio
+pytest-cov
 reorder-python-imports

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,5 +2,5 @@ asyncpg
 databases
 discord.py
 httpx
-openai
+openai>=2.41.0,<3
 python-dotenv

--- a/tests/coverage.ini
+++ b/tests/coverage.ini
@@ -1,0 +1,6 @@
+[run]
+branch = True
+source = app
+
+[report]
+show_missing = True

--- a/tests/test_ai_conversations.py
+++ b/tests/test_ai_conversations.py
@@ -1,0 +1,121 @@
+from typing import Any
+
+import pytest
+
+from app import openai_functions
+from app.adapters.openai import gpt
+from app.usecases import ai_conversations
+
+
+def test_message_content_from_prompt_includes_urls_and_attachments():
+    prompt, content = ai_conversations._message_content_from_prompt(
+        "User #123: can you read https://example.com/code.png",
+        ["https://cdn.discordapp.com/attachment.jpg"],
+    )
+
+    assert prompt == "User #123: can you read {IMAGE #1}"
+    assert content == [
+        {
+            "type": "text",
+            "text": "User #123: can you read {IMAGE #1}",
+        },
+        {
+            "type": "image_url",
+            "image_url": {"url": "https://example.com/code.png"},
+        },
+        {
+            "type": "image_url",
+            "image_url": {"url": "https://cdn.discordapp.com/attachment.jpg"},
+        },
+    ]
+
+
+@pytest.mark.asyncio
+async def test_make_gpt_request_continues_responses_function_call(
+    monkeypatch,
+):
+    responses = [
+        gpt.AIResponse(
+            response_content=None,
+            function_calls=[
+                gpt.FunctionCall(
+                    name="get_weather_for_location",
+                    arguments='{"location": "Tokyo"}',
+                    call_id="call_123",
+                )
+            ],
+            input_tokens=10,
+            output_tokens=2,
+            response_items=[
+                {
+                    "type": "function_call",
+                    "name": "get_weather_for_location",
+                    "arguments": '{"location": "Tokyo"}',
+                    "call_id": "call_123",
+                }
+            ],
+        ),
+        gpt.AIResponse(
+            response_content="Tokyo is 22C.",
+            function_calls=[],
+            input_tokens=12,
+            output_tokens=4,
+            response_items=[],
+        ),
+    ]
+    captured_context_items: list[list[dict[str, Any]]] = []
+
+    async def fake_send(
+        *,
+        model: gpt.AIModel,
+        messages: list[gpt.Message],
+        functions: list[gpt.FunctionSchema],
+        response_context_items: list[dict[str, Any]],
+    ) -> gpt.AIResponse:
+        captured_context_items.append(list(response_context_items))
+        return responses.pop(0)
+
+    async def fake_weather_callback(location: str) -> gpt.MessageContent:
+        return {"type": "text", "text": f"{location} is 22C."}
+
+    monkeypatch.setattr(gpt, "send", fake_send)
+    monkeypatch.setattr(
+        openai_functions,
+        "get_full_openai_functions_schema",
+        lambda: [],
+    )
+    monkeypatch.setitem(
+        openai_functions.ai_functions,
+        "get_weather_for_location",
+        {"callback": fake_weather_callback, "schema": {}},
+    )
+
+    result = await ai_conversations._make_gpt_request(
+        [
+            {
+                "role": "user",
+                "content": [{"type": "text", "text": "weather in Tokyo?"}],
+            }
+        ],
+        gpt.AIModel.OPENAI_GPT_5_4,
+    )
+
+    assert result == ai_conversations._GptRequestResponse(
+        response_content="Tokyo is 22C.",
+        input_tokens=22,
+        output_tokens=6,
+    )
+    assert captured_context_items[0] == []
+    assert captured_context_items[1] == [
+        {
+            "type": "function_call",
+            "name": "get_weather_for_location",
+            "arguments": '{"location": "Tokyo"}',
+            "call_id": "call_123",
+        },
+        {
+            "type": "function_call_output",
+            "call_id": "call_123",
+            "output": "Tokyo is 22C.",
+        },
+    ]

--- a/tests/test_openai_adapter.py
+++ b/tests/test_openai_adapter.py
@@ -1,0 +1,90 @@
+from dataclasses import dataclass
+from dataclasses import field
+from typing import Any
+
+import pytest
+
+from app.adapters.openai import gpt
+
+
+@dataclass
+class _FakeUsage:
+    input_tokens: int = 11
+    output_tokens: int = 7
+
+
+class _FakeOutputItem:
+    type = "message"
+
+    def model_dump(self, *, exclude_none: bool) -> dict[str, str]:
+        return {"type": self.type}
+
+
+@dataclass
+class _FakeResponse:
+    output_text: str = "done"
+    usage: _FakeUsage = field(default_factory=_FakeUsage)
+    output: list[_FakeOutputItem] = field(default_factory=lambda: [_FakeOutputItem()])
+
+
+@pytest.mark.asyncio
+async def test_openai_send_uses_responses_api_with_image_content(monkeypatch):
+    captured_kwargs: dict[str, Any] = {}
+
+    async def fake_create(**kwargs: Any) -> _FakeResponse:
+        captured_kwargs.update(kwargs)
+        return _FakeResponse()
+
+    monkeypatch.setattr(gpt.openai_client.responses, "create", fake_create)
+
+    response = await gpt.send(
+        model=gpt.AIModel.OPENAI_GPT_5_4,
+        messages=[
+            {
+                "role": "user",
+                "content": [
+                    {"type": "text", "text": "can you read this?"},
+                    {
+                        "type": "image_url",
+                        "image_url": {"url": "https://example.com/code.png"},
+                    },
+                ],
+            }
+        ],
+    )
+
+    assert captured_kwargs["model"] == "gpt-5.4"
+    assert captured_kwargs["store"] is False
+    assert captured_kwargs["input"] == [
+        {
+            "role": "user",
+            "content": [
+                {"type": "input_text", "text": "can you read this?"},
+                {
+                    "type": "input_image",
+                    "image_url": "https://example.com/code.png",
+                    "detail": "auto",
+                },
+            ],
+        }
+    ]
+    assert response.response_content == "done"
+    assert response.input_tokens == 11
+    assert response.output_tokens == 7
+
+
+def test_function_call_output_item_uses_responses_call_id():
+    function_call = gpt.FunctionCall(
+        name="get_weather_for_location",
+        arguments='{"location": "Tokyo"}',
+        call_id="call_123",
+    )
+
+    assert gpt.function_call_output_item(
+        function_call,
+        {"type": "text", "text": "22C"},
+    ) == {
+        "type": "function_call_output",
+        "call_id": "call_123",
+        "output": "22C",
+    }


### PR DESCRIPTION
## Summary
- Add current OpenAI model choices (`gpt-5.5`, `gpt-5.4`, `gpt-5.4-mini`, `gpt-5.4-nano`) and switch the default model to `gpt-5.4`.
- Route OpenAI models through the Responses API while keeping DeepSeek on its OpenAI-compatible chat endpoint.
- Include Discord image attachments in model input and preserve function-call continuation items for Responses.
- Add focused pytest coverage for image conversion and function-call continuation.

## Tests
- `venv/bin/python -m pytest tests -q`
- `venv/bin/python -m pytest tests --cov-config=tests/coverage.ini --cov=app --cov-report=term -q`
- `venv/bin/pre-commit run -a`