### PR TITLE
Fix bot maintenance oddities

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,8 @@
 #!/usr/bin/make
 
 install:
-	python3.11 -m virtualenv venv
-	. venv/bin/activate
-	pip install -r requirements.txt -r requirements-dev.txt
+	python3.11 -m venv venv
+	venv/bin/pip install -r requirements.txt -r requirements-dev.txt
 
 build: # build all containers
 	if [ -d "pgdata" ]; then sudo chmod -R 755 pgdata; fi

--- a/app/adapters/database.py
+++ b/app/adapters/database.py
@@ -78,10 +78,8 @@ class Database:
 
     async def connect(self) -> None:
         await self.pool.connect()
-        await self.pool.connect()
 
     async def disconnect(self) -> None:
-        await self.pool.disconnect()
         await self.pool.disconnect()
 
     async def fetch_one(

--- a/app/main.py
+++ b/app/main.py
@@ -75,7 +75,7 @@ async def on_message(message: discord.Message):
         await message.channel.send(msg)
 
 
-async def _calculate_per_user_costs(
+async def _calculate_per_requester_costs(
     thread_id: int | None = None, created_at_gte: datetime | None = None
 ) -> dict[int, float]:
     messages = await thread_messages.fetch_many(
@@ -83,8 +83,8 @@ async def _calculate_per_user_costs(
         created_at_gte=created_at_gte,
     )
     threads_cache: dict[int, threads.Thread] = {}
-    per_user_per_model_input_tokens: dict[int, dict[gpt.AIModel, int]] = defaultdict(
-        lambda: defaultdict(int)
+    per_requester_per_model_input_tokens: dict[int, dict[gpt.AIModel, int]] = (
+        defaultdict(lambda: defaultdict(int))
     )
     for message in messages:
         if message.role != "user":
@@ -104,19 +104,19 @@ async def _calculate_per_user_costs(
             threads_cache[thread_id] = thread
 
         user_id = message.discord_user_id
-        per_model_input_tokens = per_user_per_model_input_tokens[user_id]
+        per_model_input_tokens = per_requester_per_model_input_tokens[user_id]
         per_model_input_tokens[thread.model] += message.tokens_used
 
-    per_user_cost: dict[int, float] = defaultdict(float)
-    for user_id, per_model_tokens in per_user_per_model_input_tokens.items():
+    per_requester_cost: dict[int, float] = defaultdict(float)
+    for user_id, per_model_tokens in per_requester_per_model_input_tokens.items():
         for model, input_tokens in per_model_tokens.items():
-            user_cost = per_user_cost[user_id]
-            user_cost += openai_pricing.tokens_to_dollars(
+            requester_cost = per_requester_cost[user_id]
+            requester_cost += openai_pricing.tokens_to_dollars(
                 model, input_tokens, output_tokens=0
             )
-            per_user_cost[user_id] = user_cost
+            per_requester_cost[user_id] = requester_cost
 
-    return per_user_cost
+    return per_requester_cost
 
 
 @command_tree.command(name=command_name("monthlycost"))
@@ -130,17 +130,18 @@ async def monthlycost(interaction: discord.Interaction):
 
     await interaction.response.defer()
 
-    per_user_cost = await _calculate_per_user_costs(
+    per_requester_cost = await _calculate_per_requester_costs(
         created_at_gte=datetime.now() - timedelta(days=30)
     )
-    response_cost = sum(per_user_cost.values())
+    response_cost = sum(per_requester_cost.values())
 
     message_chunks = [
-        "**Monthly Cost Breakdown**",
-        "**----------------------**",
+        "**Monthly Requester Cost Breakdown**",
+        "**--------------------------------**",
+        "Input cost is attributed to the user who sent each model request.",
         "",
     ]
-    for user_id, cost in per_user_cost.items():
+    for user_id, cost in per_requester_cost.items():
         user = await bot.fetch_user(user_id)
         message_chunks.append(f"{user.mention}: ${cost:.5f}")
 
@@ -168,15 +169,18 @@ async def threadcost(interaction: discord.Interaction):
 
     await interaction.response.defer()
 
-    per_user_cost = await _calculate_per_user_costs(thread_id=interaction.channel.id)
-    response_cost = sum(per_user_cost.values())
+    per_requester_cost = await _calculate_per_requester_costs(
+        thread_id=interaction.channel.id
+    )
+    response_cost = sum(per_requester_cost.values())
 
     message_chunks = [
-        "**Thread Cost Breakdown**",
-        "**---------------------**",
+        "**Thread Requester Cost Breakdown**",
+        "**-------------------------------**",
+        "Input cost is attributed to the user who sent each model request.",
         "",
     ]
-    for user_id, cost in per_user_cost.items():
+    for user_id, cost in per_requester_cost.items():
         user = await bot.fetch_user(user_id)
         message_chunks.append(f"{user.mention}: ${cost:.5f}")
 
@@ -192,7 +196,7 @@ async def model(
     model: gpt.AIModel,
 ):
     if not isinstance(interaction.channel, discord.Thread):
-        await interaction.followup.send(
+        await interaction.response.send_message(
             "This command can only be used in threads.",
             ephemeral=True,
         )
@@ -234,7 +238,7 @@ async def context(
     context_length: int,
 ):
     if not isinstance(interaction.channel, discord.Thread):
-        await interaction.followup.send(
+        await interaction.response.send_message(
             "This command can only be used in threads.",
             ephemeral=True,
         )
@@ -299,7 +303,7 @@ async def summarize(
 
     await interaction.response.defer()
 
-    limit = max(num_messages, MAX_CONTENT_LENGTH)
+    limit = min(num_messages, MAX_CONTENT_LENGTH)
 
     start_message_id = None
     if start_message is not None:
@@ -319,7 +323,7 @@ async def summarize(
         if not content:  # ignore empty messages (e.g. only images)
             continue
 
-        author_name = ai_conversations.get_author_name(message.author.name)
+        author_name = ai_conversations.get_author_name(message.author.id)
 
         if tracking:
             messages.append(
@@ -439,7 +443,7 @@ async def transcript(
     context_length: int | None = None,
 ):
     if not isinstance(interaction.channel, discord.Thread):
-        await interaction.followup.send(
+        await interaction.response.send_message(
             "This command can only be used in threads.",
             ephemeral=True,
         )
@@ -462,10 +466,18 @@ async def transcript(
         )
         return
 
-    current_thread_messages = await thread_messages.fetch_many(
-        thread_id=interaction.channel.id,
-        page_size=context_length,
-    )
+    if context_length is None:
+        current_thread_messages = await thread_messages.fetch_many(
+            thread_id=interaction.channel.id
+        )
+    else:
+        current_thread_messages = await thread_messages.fetch_many(
+            thread_id=interaction.channel.id,
+            page=1,
+            page_size=context_length,
+            sort_order="desc",
+        )
+        current_thread_messages = current_thread_messages[::-1]
 
     transcript_content = "\n".join(
         f"[{msg.created_at:%d/%m/%Y %I:%M:%S%p}] {msg.content}"

--- a/app/openai_functions.py
+++ b/app/openai_functions.py
@@ -152,14 +152,13 @@ async def get_weather_for_location(
         params={
             "latitude": latitude,
             "longitude": longitude,
-            "hourly": "temperature_2m",
-            "timeformat": "unixtime",
+            "current": "temperature_2m",
         },
     )
     response.raise_for_status()
     response_data = response.json()
 
-    degrees_celcius = response_data["hourly"]["temperature_2m"][-1]
+    degrees_celcius = response_data["current"]["temperature_2m"]
     degrees_fahrenheit = celcius_to_fahrenheit(degrees_celcius)
 
     return {

--- a/app/repositories/thread_messages.py
+++ b/app/repositories/thread_messages.py
@@ -82,6 +82,7 @@ async def fetch_many(
     created_at_gte: datetime | None = None,
     page: int | None = None,
     page_size: int | None = None,
+    sort_order: Literal["asc", "desc"] = "asc",
 ) -> list[ThreadMessage]:
     query = f"""\
         SELECT {READ_PARAMS}
@@ -96,10 +97,12 @@ async def fetch_many(
         "role": role,
     }
     if created_at_gte is not None:
-        query += "AND created_at >= :created_at_gte"
+        query += " AND created_at >= :created_at_gte"
         values["created_at_gte"] = created_at_gte
+    order_sql = "DESC" if sort_order == "desc" else "ASC"
+    query += f" ORDER BY created_at {order_sql}, thread_message_id {order_sql}"
     if page is not None and page_size is not None:
-        query += "LIMIT :page_size OFFSET :offset"
+        query += " LIMIT :page_size OFFSET :offset"
         values["page_size"] = page_size
         values["offset"] = (page - 1) * page_size
     recs = await state.read_database.fetch_all(query, values)

--- a/app/usecases/ai_conversations.py
+++ b/app/usecases/ai_conversations.py
@@ -1,5 +1,6 @@
 import json
 import traceback
+from hashlib import sha256
 from typing import Any
 from typing import NamedTuple
 
@@ -38,13 +39,12 @@ DISCORD_USER_ID_WHITELIST: set[int] = {
 }
 
 
-def _get_author_id(author_name: str) -> int:
-    # get a 3 digit highly unique id
-    return hash(author_name) % 1000
+def _get_author_id(discord_user_id: int) -> str:
+    return sha256(str(discord_user_id).encode()).hexdigest()[:8]
 
 
-def get_author_name(discord_author_name: str) -> str:
-    return f"User #{_get_author_id(discord_author_name)}"
+def get_author_name(discord_user_id: int) -> str:
+    return f"User #{_get_author_id(discord_user_id)}"
 
 
 class _GptRequestResponse(NamedTuple):
@@ -194,7 +194,7 @@ async def send_message_to_thread(
     if prompt.startswith(f"{bot.user.mention} "):
         prompt = prompt.removeprefix(f"{bot.user.mention} ")
 
-    author_name = get_author_name(message.author.name)
+    author_name = get_author_name(message.author.id)
     prompt = f"{author_name}: {prompt}"
 
     async with message.channel.typing():

--- a/tests/test_ai_conversations.py
+++ b/tests/test_ai_conversations.py
@@ -1,3 +1,4 @@
+import re
 from typing import Any
 
 import pytest
@@ -5,6 +6,14 @@ import pytest
 from app import openai_functions
 from app.adapters.openai import gpt
 from app.usecases import ai_conversations
+
+
+def test_get_author_name_uses_stable_pseudonym():
+    author_name = ai_conversations.get_author_name(285190493703503872)
+
+    assert re.fullmatch(r"User #[0-9a-f]{8}", author_name)
+    assert author_name == ai_conversations.get_author_name(285190493703503872)
+    assert author_name != ai_conversations.get_author_name(285190493703503873)
 
 
 def test_message_content_from_prompt_includes_urls_and_attachments():

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -1,0 +1,103 @@
+from datetime import datetime
+from typing import Any
+
+import pytest
+
+from app import state
+from app.adapters import database
+from app.repositories import thread_messages
+
+
+class _FakePool:
+    def __init__(self) -> None:
+        self.connect_calls = 0
+        self.disconnect_calls = 0
+
+    async def connect(self) -> None:
+        self.connect_calls += 1
+
+    async def disconnect(self) -> None:
+        self.disconnect_calls += 1
+
+
+@pytest.mark.asyncio
+async def test_database_connect_and_disconnect_call_pool_once():
+    pool = _FakePool()
+    db = object.__new__(database.Database)
+    db.pool = pool
+
+    await db.connect()
+    await db.disconnect()
+
+    assert pool.connect_calls == 1
+    assert pool.disconnect_calls == 1
+
+
+class _FakeReadDatabase:
+    def __init__(self) -> None:
+        self.query: str | None = None
+        self.values: dict[str, Any] | None = None
+
+    async def fetch_all(
+        self,
+        query: str,
+        values: dict[str, Any],
+    ) -> list[dict[str, Any]]:
+        self.query = " ".join(query.split())
+        self.values = values
+        return []
+
+
+@pytest.mark.asyncio
+async def test_thread_message_fetch_many_orders_before_pagination(monkeypatch):
+    read_database = _FakeReadDatabase()
+    monkeypatch.setattr(state, "read_database", read_database, raising=False)
+    created_at_gte = datetime(2026, 1, 1)
+
+    await thread_messages.fetch_many(
+        thread_id=123,
+        created_at_gte=created_at_gte,
+        page=2,
+        page_size=50,
+    )
+
+    assert read_database.query is not None
+    assert (
+        "created_at >= :created_at_gte "
+        "ORDER BY created_at ASC, thread_message_id ASC "
+        "LIMIT :page_size OFFSET :offset"
+    ) in read_database.query
+    assert read_database.values == {
+        "thread_id": 123,
+        "discord_user_id": None,
+        "role": None,
+        "created_at_gte": created_at_gte,
+        "page_size": 50,
+        "offset": 50,
+    }
+
+
+@pytest.mark.asyncio
+async def test_thread_message_fetch_many_can_page_latest_messages(monkeypatch):
+    read_database = _FakeReadDatabase()
+    monkeypatch.setattr(state, "read_database", read_database, raising=False)
+
+    await thread_messages.fetch_many(
+        thread_id=123,
+        page=1,
+        page_size=10,
+        sort_order="desc",
+    )
+
+    assert read_database.query is not None
+    assert (
+        "ORDER BY created_at DESC, thread_message_id DESC "
+        "LIMIT :page_size OFFSET :offset"
+    ) in read_database.query
+    assert read_database.values == {
+        "thread_id": 123,
+        "discord_user_id": None,
+        "role": None,
+        "page_size": 10,
+        "offset": 0,
+    }

--- a/tests/test_openai_functions.py
+++ b/tests/test_openai_functions.py
@@ -1,0 +1,64 @@
+from typing import Any
+
+import pytest
+
+from app import openai_functions
+from app import state
+
+
+class _FakeResponse:
+    def __init__(self, data: dict[str, Any]) -> None:
+        self.data = data
+
+    def raise_for_status(self) -> None:
+        return None
+
+    def json(self) -> dict[str, Any]:
+        return self.data
+
+
+class _FakeHttpClient:
+    def __init__(self) -> None:
+        self.requests: list[tuple[str, dict[str, Any]]] = []
+
+    async def get(self, url: str, params: dict[str, Any]) -> _FakeResponse:
+        self.requests.append((url, params))
+        if "geocode" in url:
+            return _FakeResponse(
+                {
+                    "results": [
+                        {
+                            "geometry": {
+                                "location": {
+                                    "lat": 35.6764,
+                                    "lng": 139.65,
+                                },
+                            },
+                        },
+                    ],
+                }
+            )
+
+        return _FakeResponse({"current": {"temperature_2m": 22.3}})
+
+
+@pytest.mark.asyncio
+async def test_weather_function_uses_current_temperature(monkeypatch):
+    http_client = _FakeHttpClient()
+    monkeypatch.setattr(state, "http_client", http_client, raising=False)
+    monkeypatch.setattr(openai_functions, "location_cache", {})
+
+    response = await openai_functions.get_weather_for_location("Tokyo")
+
+    assert response == {
+        "type": "text",
+        "text": "22.3°C / 72.14°F",
+    }
+    assert http_client.requests[1] == (
+        "https://api.open-meteo.com/v1/forecast",
+        {
+            "latitude": 35.6764,
+            "longitude": 139.65,
+            "current": "temperature_2m",
+        },
+    )


### PR DESCRIPTION
## Summary
- make database pool lifecycle calls single-shot and make thread message reads deterministic
- use stable Discord-ID pseudonyms, current weather responses, and clearer requester-based cost labels
- fix early interaction error responses, summarize limit capping, transcript limiting, and venv installation
- add focused regression coverage for stable labels, DB lifecycle/query ordering, and current-weather parsing

## Tests
- ./venv/bin/pre-commit run -a
- ./venv/bin/python -m pytest